### PR TITLE
Add notional RELAX NG schemas to test fixtures folder.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,9 @@
-# content-validator
+content-validator
+===================
+
 Validate XML against the Libero content model
+
+Schemas for testing
+===================
+
+Schemas for validating against in tests are copied from the `schemas <https://github.com/libero/schemas>`__ project. Currently only the RELAX NG files (\*.rng) are required for validating in the automated test scenarios.

--- a/tests/fixtures/schemas/api/content/data/content.rng
+++ b/tests/fixtures/schemas/api/content/data/content.rng
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+
+    <include href="../../../core/data/core.rng"/>
+
+    <start>
+        <ref name="libero.content"/>
+    </start>
+
+    <div>
+
+        <a:documentation>content element</a:documentation>
+
+        <define name="libero.content">
+
+            <element name="content">
+
+                <oneOrMore>
+                    <ref name="libero.anything.element"/>
+                </oneOrMore>
+
+            </element>
+
+        </define>
+
+    </div>
+
+</grammar>

--- a/tests/fixtures/schemas/api/content/data/parts/front.rng
+++ b/tests/fixtures/schemas/api/content/data/parts/front.rng
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+
+    <include href="../../../../core/data/core.rng"/>
+
+    <start>
+        <ref name="libero.content.front"/>
+    </start>
+
+    <div>
+
+        <a:documentation>front element</a:documentation>
+
+        <define name="libero.content.front">
+
+            <element name="front">
+                <ref name="libero.content.front.attributes"/>
+                <ref name="libero.content.front.content"/>
+            </element>
+
+        </define>
+
+        <define name="libero.content.front.attributes">
+            <ref name="libero.attributes.lang"/>
+        </define>
+
+        <define name="libero.content.front.content">
+
+            <interleave>
+                <ref name="libero.content.front.content.id"/>
+                <ref name="libero.content.front.content.title"/>
+            </interleave>
+
+        </define>
+
+    </div>
+
+    <div>
+
+        <a:documentation>front/id element</a:documentation>
+
+        <define name="libero.content.front.content.id">
+
+            <element name="id">
+                <ref name="libero.content.front.content.id.attributes"/>
+                <ref name="libero.content.front.content.id.content"/>
+            </element>
+
+        </define>
+
+        <define name="libero.content.front.content.id.attributes">
+            <empty/>
+        </define>
+
+        <define name="libero.content.front.content.id.content">
+            <ref name="libero.types.id"/>
+        </define>
+
+    </div>
+
+    <div>
+
+        <a:documentation>front/title element</a:documentation>
+
+        <define name="libero.content.front.content.title">
+
+            <element name="title">
+                <ref name="libero.content.front.content.title.attributes"/>
+                <ref name="libero.content.front.content.title.content"/>
+            </element>
+
+        </define>
+
+        <define name="libero.content.front.content.title.attributes">
+            <empty/>
+        </define>
+
+        <define name="libero.content.front.content.title.content">
+            <ref name="libero.text.limited"/>
+        </define>
+
+    </div>
+
+</grammar>

--- a/tests/fixtures/schemas/core/data/any.rng
+++ b/tests/fixtures/schemas/core/data/any.rng
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+    xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <define name="libero.anything">
+        <interleave>
+            <zeroOrMore>
+                <ref name="libero.anything.element"/>
+            </zeroOrMore>
+            <text/>
+        </interleave>
+    </define>
+
+    <define name="libero.anything.element">
+        <element>
+            <anyName/>
+            <zeroOrMore>
+                <ref name="libero.anything.attribute"/>
+            </zeroOrMore>
+            <zeroOrMore>
+                <ref name="libero.anything"/>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="libero.anything.attribute">
+        <attribute>
+            <anyName/>
+        </attribute>
+    </define>
+
+</grammar>

--- a/tests/fixtures/schemas/core/data/attributes.rng
+++ b/tests/fixtures/schemas/core/data/attributes.rng
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar ns="http://libero.pub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+
+    <div>
+
+        <a:documentation>@xml:lang attribute</a:documentation>
+
+        <define name="libero.attributes.lang">
+
+            <attribute name="xml:lang">
+                <ref name="libero.attributes.lang.content"/>
+            </attribute>
+
+        </define>
+
+        <define name="libero.attributes.lang.content">
+            <data type="language"/>
+        </define>
+
+    </div>
+
+</grammar>

--- a/tests/fixtures/schemas/core/data/core.rng
+++ b/tests/fixtures/schemas/core/data/core.rng
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
+
+    <include href="any.rng"/>
+    <include href="attributes.rng"/>
+    <include href="inline.rng"/>
+    <include href="types.rng"/>
+    
+</grammar>

--- a/tests/fixtures/schemas/core/data/error.rng
+++ b/tests/fixtures/schemas/core/data/error.rng
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- As specified in https://www.ietf.org/rfc/rfc7807.txt -->
+
+<grammar ns="urn:ietf:rfc:7807" xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="problem"/>
+    </start>
+
+    <define name="problem">
+
+        <element name="problem">
+
+            <interleave>
+
+                <optional>
+
+                    <element name="type">
+                        <data type="anyURI"/>
+                    </element>
+                    
+                    <element name="title">
+                        <data type="string"/>
+                    </element>
+
+                    <element name="detail">
+                        <data type="string"/>
+                    </element>
+
+                    <element name="status">
+                        <data type="positiveInteger"/>
+                    </element>
+
+                    <element name="instance">
+                        <data type="anyURI"/>
+                    </element>
+
+                </optional>
+
+            </interleave>
+
+            <ref name="anyNsElement"/>
+
+        </element>
+
+    </define>
+
+    <define name="anyNsElement">
+
+        <zeroOrMore>
+
+            <choice>
+
+                <element>
+
+                    <nsName/>
+
+                    <choice>
+
+                        <ref name="anyNsElement"/>
+                        <text/>
+
+                    </choice>
+
+                </element>
+
+                <attribute>
+                    <anyName/>
+                </attribute>
+
+            </choice>
+
+        </zeroOrMore>
+
+    </define>
+
+</grammar>

--- a/tests/fixtures/schemas/core/data/inline.rng
+++ b/tests/fixtures/schemas/core/data/inline.rng
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <define name="libero.text.limited">
+
+        <oneOrMore>
+
+            <choice>
+                <ref name="libero.text.limited.content"/>
+            </choice>
+
+        </oneOrMore>
+
+    </define>
+
+    <define name="libero.text.limited.content">
+        <text/>
+    </define>
+
+</grammar>

--- a/tests/fixtures/schemas/core/data/types.rng
+++ b/tests/fixtures/schemas/core/data/types.rng
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <define name="libero.types.id">
+
+        <data type="string">
+            <param name="pattern">\s*[A-Za-z0-9\-._]+\s*</param>
+        </data>
+
+    </define>
+
+</grammar>


### PR DESCRIPTION
Just the ``.rng`` files from schemas project PR https://github.com/libero/schemas/pull/1.

Adding the schemas to this project will make testing consistent and easy. 

Alternatively, or in the future, we might be able to pin the schemas in this validator project to a specific commit of the schemas project. Copying them over now will allow code and tests to be added to this project more quickly.